### PR TITLE
Database Scripts

### DIFF
--- a/db/drop.sql
+++ b/db/drop.sql
@@ -1,5 +1,0 @@
-use OlevilleVoting;
-
-DROP TABLE Voter;
-DROP TABLE Position;
-DROP TABLE Election;

--- a/db/drop.sql
+++ b/db/drop.sql
@@ -1,0 +1,5 @@
+use OlevilleVoting;
+
+DROP TABLE Voter;
+DROP TABLE Position;
+DROP TABLE Election;

--- a/db/dropAllTables.sql
+++ b/db/dropAllTables.sql
@@ -1,0 +1,14 @@
+use OlevilleVoting;
+
+SET foreign_key_checks = 0;
+
+DROP TABLE IF EXISTS Election;
+DROP TABLE IF EXISTS Voter;
+DROP TABLE IF EXISTS Position;
+DROP TABLE IF EXISTS Candidate;
+DROP TABLE IF EXISTS Vote;
+DROP TABLE IF EXISTS VoterGroup;
+DROP TABLE IF EXISTS VoterGroupAssoc;
+
+SET foreign_key_checks = 1;
+

--- a/db/initTables.sql
+++ b/db/initTables.sql
@@ -1,0 +1,60 @@
+use OlevilleVoting;
+
+CREATE TABLE Election (
+	id INTEGER NOT NULL AUTO_INCREMENT,
+	name VARCHAR(100),
+	PRIMARY KEY (id)
+);
+
+CREATE TABLE Voter (
+	id INTEGER NOT NULL AUTO_INCREMENT,
+	name VARCHAR(100) NOT NULL,
+	electionId INTEGER,
+	PRIMARY KEY (id),
+	CONSTRAINT FK_voter_electionId FOREIGN KEY (`electionId`) REFERENCES `Election`(`id`)
+);
+
+CREATE TABLE Position (
+	id INTEGER NOT NULL AUTO_INCREMENT,
+	name VARCHAR(100) NOT NULL,
+	electionId INTEGER,
+	PRIMARY KEY (id),
+	CONSTRAINT FK_position_electionId FOREIGN KEY (`electionId`) REFERENCES `Election`(`id`)
+);
+
+CREATE TABLE Candidate (
+	id INTEGER NOT NULL AUTO_INCREMENT,
+	name VARCHAR(100) NOT NULL,
+	description VARCHAR(5000),
+	positionId INTEGER,
+	electionId INTEGER,
+	PRIMARY KEY (id),
+	CONSTRAINT FK_candidate_positionId FOREIGN KEY (`positionId`) REFERENCES `Position`(`id`),
+	CONSTRAINT FK_candidate_electionId FOREIGN KEY (`electionId`) REFERENCES `Election`(`id`)
+);
+
+CREATE TABLE Vote (
+	id INTEGER NOT NULL AUTO_INCREMENT,
+	candidateId INTEGER,
+	voterId INTEGER,
+	electionId INTEGER,
+	positionId INTEGER,
+	PRIMARY KEY (id),
+	CONSTRAINT FK_vote_candidateId FOREIGN KEY (`candidateId`) REFERENCES `Candidate`(`id`),
+	CONSTRAINT FK_vote_voterId FOREIGN KEY (`voterId`) REFERENCES `Voter`(`id`),
+	CONSTRAINT FK_vote_electionId FOREIGN KEY (`electionId`) REFERENCES `Election`(`id`),
+	CONSTRAINT FK_vote_positionId FOREIGN KEY (`positionId`) REFERENCES `Position`(`id`)
+);
+
+CREATE TABLE VoterGroup (
+	id INTEGER NOT NULL AUTO_INCREMENT,
+	name VARCHAR(100),
+	PRIMARY KEY (id)
+);
+
+CREATE TABLE VoterGroupAssoc (
+	voterId INTEGER,
+	voterGroupId INTEGER,
+	CONSTRAINT FK_voterGroupAssoc_voterId FOREIGN KEY (`voterId`) REFERENCES `Voter`(`id`),
+	CONSTRAINT FK_voterGroupAssoc_voterGroupId FOREIGN KEY (`voterGroupId`) REFERENCES `VoterGroup`(`id`)
+);

--- a/db/initTables.sql
+++ b/db/initTables.sql
@@ -3,6 +3,8 @@ use OlevilleVoting;
 CREATE TABLE Election (
 	id INTEGER NOT NULL AUTO_INCREMENT,
 	name VARCHAR(100),
+	startDateTime DATETIME,
+	endDateTime DATETIME,
 	PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
The first of a few PRs that make setting up the DB for development (and production) easy. I'm planning on doing one to insert testing data, and maybe another to actually set up the database (although that's a one-time operation).

The init script expects that you already have a local mysql instance running, with a database called `OlevilleVoting` in in, and that your current user has permission to create tables. The drop script is similar and can be used to get out of a bad state.