### PR TITLE
Add general autosave extensions to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@ node_modules
 # Debug log from npm
 npm-debug.log
 
-# Temp files
+# Editor temporary files
 *.swp
+*~
+\#*\#


### PR DESCRIPTION
Many editors also use `~` as an appended character to indicate autosave data.  Emacs uses this style for file history and also uses `#filename#` for autosaves between saves.

This PR adds these to the `.gitignore` file to ensure that these files do not get committed, and is meant to get merged into the `database-connection` branch.