### PR TITLE
Add MySQL as a service dependency in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 sudo: false
+services:
+  - mysql
 node_js:
   - "node"
 cache:


### PR DESCRIPTION
We can probably benefit from having this in our testing environment.  I could also foresee adding Postgres and any other possible databases that we might want to test against here.