### PR TITLE
Query String Cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(cookieParser())
 
+// Plural routes
 app.use('/elections', elections)
 app.use('/candidates', candidates)
 app.use('/positions', positions)
@@ -23,6 +24,16 @@ app.use('/users', users)
 app.use('/voterGroups', voterGroups)
 app.use('/voters', voters)
 app.use('/votes', votes)
+s
+// Singular routes
+app.use('/election', elections)
+app.use('/candidate', candidates)
+app.use('/position', positions)
+app.use('/user', users)
+app.use('/voterGroup', voterGroups)
+app.use('/voter', voters)
+app.use('/vote', votes)
+
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -17,10 +17,10 @@ router.get('/:candidateId?', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.Candidate.create({
-		name: req.body.name,
-		description: req.body.description,
-		electionId: req.body.electionId,
-		positionId: req.body.positionId
+		name: req.query.name,
+		description: req.query.description,
+		electionId: req.query.electionId,
+		positionId: req.query.positionId
 	})
 	.then(() => {
 		res.sendStatus(201) // Created
@@ -41,10 +41,10 @@ router.patch('/:candidateId', (req, res) => {
 			res.sendStatus(404)
 			return
 		}
-		candidate.name = req.body.name || candidate.name
-		candidate.description = req.body.description || candidate.description
-		candidate.electionId = req.body.electionId || candidate.electionId
-		candidate.positionId = req.body.positionId || candidate.positionId
+		candidate.name = req.query.name || candidate.name
+		candidate.description = req.query.description || candidate.description
+		candidate.electionId = req.query.electionId || candidate.electionId
+		candidate.positionId = req.query.positionId || candidate.positionId
 		candidate.save().then(() => {
 			res.sendStatus(202)
 		})

--- a/routes/elections.js
+++ b/routes/elections.js
@@ -19,8 +19,8 @@ router.get('/:electionId?', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.Election.create({
-		name: req.body.name,
-		description: req.body.description
+		name: req.query.name,
+		description: req.query.description
 	})
 	.then(() => {
 		res.sendStatus(201) // Created
@@ -41,9 +41,9 @@ router.patch('/:electionId', (req, res) => {
 			res.sendStatus(404)
 			return
 		}
-		election.name = req.body.name || election.name
-		election.startDateTime = req.body.startDateTime || election.startDateTime
-		election.endDateTime = req.body.endDateTime || election.endDateTime
+		election.name = req.query.name || election.name
+		election.startDateTime = req.query.startDateTime || election.startDateTime
+		election.endDateTime = req.query.endDateTime || election.endDateTime
 		election.save().then(() => {
 			res.sendStatus(202)
 		})

--- a/routes/positions.js
+++ b/routes/positions.js
@@ -17,9 +17,9 @@ router.get('/:positionId?', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.Position.create({
-		name: req.body.name,
-		description: req.body.description,
-		electionId: req.body.electionId
+		name: req.query.name,
+		description: req.query.description,
+		electionId: req.query.electionId
 	})
 	.then(() => {
 		res.sendStatus(201) // Created
@@ -40,9 +40,9 @@ router.patch('/:positionId', (req, res) => {
 			res.sendStatus(404)
 			return
 		}
-		pos.name = req.body.name || pos.name
-		pos.description = req.body.description || pos.description
-		pos.electionId = req.body.electionId || pos.electionId
+		pos.name = req.query.name || pos.name
+		pos.description = req.query.description || pos.description
+		pos.electionId = req.query.electionId || pos.electionId
 		pos.save().then(() => {
 			res.sendStatus(202)
 		})

--- a/routes/users.js
+++ b/routes/users.js
@@ -17,9 +17,9 @@ router.get('/:userId?', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.User.create({
-		name: req.body.name,
-		description: req.body.description,
-		electionId: req.body.electionId
+		name: req.query.name,
+		description: req.query.description,
+		electionId: req.query.electionId
 	})
 	.then(() => {
 		res.sendStatus(201) // Created

--- a/routes/voterGroups.js
+++ b/routes/voterGroups.js
@@ -17,7 +17,7 @@ router.get('/:voterGroupId', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.VoterGroup.create({
-		name: req.body.name
+		name: req.query.name
 	})
 	.then(() => {
 		res.sendStatus(201) // Created
@@ -38,7 +38,7 @@ router.patch('/:vgId', (req, res) => {
 			res.sendStatus(404)
 			return
 		}
-		vg.name = req.body.name || vg.name
+		vg.name = req.query.name || vg.name
 		vg.save().then(() => {
 			res.sendStatus(202)
 		})

--- a/routes/voters.js
+++ b/routes/voters.js
@@ -17,8 +17,8 @@ router.get('/:voterId?', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.Voter.create({
-		name: req.body.name,
-		electionId: req.body.electionId
+		name: req.query.name,
+		electionId: req.query.electionId
 	})
 	.then(() => {
 		res.sendStatus(201) // Created
@@ -39,8 +39,8 @@ router.patch('/:voterId', (req, res) => {
 			res.sendStatus(404)
 			return
 		}
-		voter.name = req.body.name || voter.name
-		voter.electionId = req.body.electionId || voter.electionId
+		voter.name = req.query.name || voter.name
+		voter.electionId = req.query.electionId || voter.electionId
 		voter.save().then(() => {
 			res.sendStatus(202)
 		})

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -15,10 +15,10 @@ router.get('/:voteId?', (req, res) => {
 
 router.post('/', (req, res) => {
 	models.Voter.create({
-		candidateId: req.body.candidateId,
-		voterId: req.body.voterId,
-		electionId: req.body.electionId,
-		positionId: req.body.positionId
+		candidateId: req.query.candidateId,
+		voterId: req.query.voterId,
+		electionId: req.query.electionId,
+		positionId: req.query.positionId
 	})
 	.then(() => {
 		res.sendStatus(201) // Created


### PR DESCRIPTION
I was pretty sloppy when I wrote the routes and used `body` and `params` in places where we should have had `query`, this fixes that.

Also added singular routes, for convenience. They operate exactly the same as the plural routes.