### PR TITLE
Add migration to add new column to Election

### DIFF
--- a/migrations/20170912031458-add-election-type-to-election.js
+++ b/migrations/20170912031458-add-election-type-to-election.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+		queryInterface.addColumn('Election', 'isRankChoice', Sequelize.BOOLEAN, {
+			allowNull: false,
+			onUpdate: 'CASCADE',
+			onDelete: 'SET NULL'
+		})
+  },
+
+  down: function (queryInterface, Sequelize) {
+		queryInterface.removeColumn('Election', 'isRankChoice')
+  }
+}

--- a/models/election.js
+++ b/models/election.js
@@ -1,13 +1,14 @@
 'use strict'
 
 module.exports = (sequelize, DataTypes) => {
-  const Election = sequelize.define('Election', {
-    name: DataTypes.STRING,
-    startDateTime: DataTypes.DATE,
-    endDateTime: DataTypes.DATE
-  }, {
+	const Election = sequelize.define('Election', {
+		name: DataTypes.STRING,
+		startDateTime: DataTypes.DATE,
+		endDateTime: DataTypes.DATE,
+		isRankChoice: DataTypes.BOOLEAN
+	}, {
 		freezeTableName: true
-  })
+	})
 
-  return Election
+	return Election
 }


### PR DESCRIPTION
This migration should add a column to the Election table, designed to allow us to know if the election at hand should use the rank choice vote tally method, or the first past the post method.

Addresses #29 