### PR TITLE
Insert token into User based on electionId

### DIFF
--- a/lib/refreshCurrentElectionInfo.js
+++ b/lib/refreshCurrentElectionInfo.js
@@ -24,7 +24,7 @@ export default async function getCurrentElectionInfo(currentElectionInfo) {
 			currentElectionInfo.id = res.id
 			currentElectionInfo.isStale = false
 			currentElectionInfo.checked = moment()
-			currentElectionInfo
+			return currentElectionInfo
 		} else {
 			// the above query did not return anything. Make a new one for a future election.
 			console.log('no election going on now, looking for upcoming election')

--- a/lib/userIsAuthenticated.js
+++ b/lib/userIsAuthenticated.js
@@ -1,9 +1,10 @@
 import models from '../models'
 
-export default function userIsAuthenticated(email, token) {
+export default function userIsAuthenticated(email, token, electionId) {
 	models.User.findOne({
 			where: {
-				email: email
+				email: email,
+				electionId: electionId
 			}
 	})
 	.then((data) => {

--- a/routes/login.js
+++ b/routes/login.js
@@ -41,7 +41,8 @@ router.post('/google', async (req, res) => {
 					tokenExpiration: moment.unix(json.exp) // this comes from google, so we trust it
 				}, {
 					where: {
-						email: json.email
+						email: json.email,
+						electionId: req.electionId
 					}
 				}
 			)


### PR DESCRIPTION
The electionId should be the current electionId, as determined by the
middleware, since there will likely be multiple users in the database
with the same email, one for each election that they can participate in.