### PR TITLE
Secure routes, complete Auth flow, fix various issues with API

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import bodyParser from 'body-parser'
 import { CLIENT_ID, CLIENT_SECRET, SESSION_SECRET } from './config.js'
 import models from './models'
 import moment from 'moment'
+import setUserInfo from './lib/setUserInfo'
 import refreshCurrentElectionInfo from './lib/refreshCurrentElectionInfo'
 
 const Strategy = require('passport-google-oauth').Strategy
@@ -60,6 +61,18 @@ app.use(async (req, res, next) => {
 	req.electionId = currentElectionInfo.id
 	next()
 	return
+})
+
+// authentication middleware
+app.use(async (req, res, next) => {
+	// if the user is trying to log in, then we don't care what their status is
+	if (req.originalUrl.includes('login')) {
+		next()
+	}
+
+	// if the user's authentication header is set, we can get their information and add it to the req object
+	req = await setUserInfo(req)
+	next()
 })
 
 // Plural routes

--- a/config.sample.js
+++ b/config.sample.js
@@ -2,3 +2,4 @@ export const CLIENT_ID = ''
 export const CLIENT_SECRET = ''
 export const SESSION_SECRET = ''
 export const CURRENT_ELECTION_INFORMATION_TIMEOUT = 60
+export const ADMIN_USERGROUP_ID = 1

--- a/lib/getToken.js
+++ b/lib/getToken.js
@@ -1,0 +1,9 @@
+const parseToken = (tokString) => {
+	let tok = tokString.match('\"(.+)\"')[1]
+	return tok
+}
+
+export default function getToken(req) {
+	let token = parseToken(req.get('Authorization'))
+	return token
+}

--- a/lib/getToken.js
+++ b/lib/getToken.js
@@ -1,9 +1,19 @@
 const parseToken = (tokString) => {
-	let tok = tokString.match('\"(.+)\"')[1]
+	let tok
+	try {
+		tok = tokString.match('\"(.+)\"')[1]
+	} catch (err) {
+		console.log('error parsing out token from Authorization header: ' + err)
+	}
 	return tok
 }
 
 export default function getToken(req) {
-	let token = parseToken(req.get('Authorization'))
-	return token
+	if (req.get('Authorization')) {
+		console.log(req.get('Authorization'))
+		let token = parseToken(req.get('Authorization'))
+		return token
+	} else {
+		return null
+	}
 }

--- a/lib/getToken.js
+++ b/lib/getToken.js
@@ -10,7 +10,6 @@ const parseToken = (tokString) => {
 
 export default function getToken(req) {
 	if (req.get('Authorization')) {
-		console.log(req.get('Authorization'))
 		let token = parseToken(req.get('Authorization'))
 		return token
 	} else {

--- a/lib/refreshCurrentElectionInfo.js
+++ b/lib/refreshCurrentElectionInfo.js
@@ -9,16 +9,22 @@ export default async function getCurrentElectionInfo(currentElectionInfo) {
 		// this info is stale. We need to get new info.
 		// finds an election that is happening now
 		console.log('info is stale. Getting new info.')
-		let res = await models.Election.findOne({
-			where: {
-				startDateTime: {
-					lt: moment()
-				},
-				endDateTime: {
-					gt: moment()
+		let res
+		try {
+			res = await models.Election.findOne({
+				where: {
+					startDateTime: {
+						lt: moment()
+					},
+					endDateTime: {
+						gt: moment()
+					}
 				}
-			}
-		})
+			})
+		} catch (err) {
+			console.log('Error getting current election info: ' + err)
+		}
+
 		if (res) {
 			console.log('got an election going on now, using that')
 			currentElectionInfo.id = res.id
@@ -36,6 +42,7 @@ export default async function getCurrentElectionInfo(currentElectionInfo) {
 					}
 				}
 			})
+
 			if (res) {
 				console.log('found an upcoming election')
 				currentElectionInfo.id = res.dataValues.id
@@ -50,7 +57,7 @@ export default async function getCurrentElectionInfo(currentElectionInfo) {
 				currentElectionInfo.checked = moment()
 				return currentElectionInfo
 			}
-	}
+		}
 	} else {
 		console.log('info is current')
 		return currentElectionInfo

--- a/lib/refreshCurrentElectionInfo.js
+++ b/lib/refreshCurrentElectionInfo.js
@@ -23,6 +23,7 @@ export default async function getCurrentElectionInfo(currentElectionInfo) {
 			})
 		} catch (err) {
 			console.log('Error getting current election info: ' + err)
+			return currentElectionInfo
 		}
 
 		if (res) {
@@ -34,14 +35,20 @@ export default async function getCurrentElectionInfo(currentElectionInfo) {
 		} else {
 			// the above query did not return anything. Make a new one for a future election.
 			console.log('no election going on now, looking for upcoming election')
-			let res = await models.Election.findOne({
-				order: sequelize.fn('min', sequelize.col('startDateTime')),
-				where: {
-					startDateTime: {
-						gt: moment()
+			let res
+			try {
+				res = await models.Election.findOne({
+					order: sequelize.fn('min', sequelize.col('startDateTime')),
+					where: {
+						startDateTime: {
+							gt: moment()
+						}
 					}
-				}
-			})
+				})
+			} catch (err) {
+				console.log('Error getting future election info: ' + err)
+				return currentElectionInfo
+			}
 
 			if (res) {
 				console.log('found an upcoming election')

--- a/lib/setUserInfo.js
+++ b/lib/setUserInfo.js
@@ -1,12 +1,12 @@
 import Sequelize from 'sequelize'
+import moment from 'moment'
 import getToken from './getToken'
 import models from '../models'
+import {ADMIN_USERGROUP_ID} from '../config'
 
 export default async function setUserInfo(req) {
-	console.log('setUserInfo')
 	if (req.get('Authorization')) {
 		let userToken = getToken(req)
-		console.log('got the token in setuserinfo')
 
 		let userData
 		try {
@@ -17,7 +17,7 @@ export default async function setUserInfo(req) {
 				include: [
 					{
 						model: models.UserGroupMembership,
-						as: 'user'
+						as: 'user',
 						include: [
 							{
 								model: models.UserGroup,
@@ -31,9 +31,24 @@ export default async function setUserInfo(req) {
 			console.log('Error getting current user from database: ' + err)
 		}
 
+		// simplify list of user's groups
+		userData.isAdmin = false
+		let userGroups = []
+		userData.user.forEach((ug) => {
+			userGroups.push({
+				id: ug.dataValues.userGroup.dataValues.id,
+				name: ug.dataValues.userGroup.dataValues.name
+			})
+			// while we're here, may as well check if the user is an admin
+			if (ug.dataValues.userGroup.dataValues.id === ADMIN_USERGROUP_ID) {
+				userData.isAdmin = true
+			}
+		})
+		userData.userGroups = userGroups
+
 		if (userData.authToken && userData.authToken == userToken && moment(userData.tokenExpiration) > moment()) {
 			// this is a valid user with a non-expired token, so set some data on their request and return it
-			req.user = userData
+			req.user = userData // attach the user to the req
 			return req
 		} else {
 			// for some reason this user is not valid, so just return the req object

--- a/lib/setUserInfo.js
+++ b/lib/setUserInfo.js
@@ -1,0 +1,24 @@
+import getToken from './getToken'
+import models from '../models'
+
+export default async function setUserInfo(req) {
+	if (req.get('Authorization')) {
+		let userToken = getToken(req)
+		let userData = await models.User.findOne({
+			where: {
+				authToken: userToken
+			}
+		})
+		if (data.authToken && data.authToken == userToken && moment(data.tokenExpiration) > moment()) {
+			// this is a valid user with a non-expired token, so set some data on their request and return it
+			req.user = data
+			return req
+		} else {
+			// for some reason this user is not valid, so just return the req object
+			return req
+		}
+	} else {
+		return req
+	}
+}
+

--- a/lib/setUserInfo.js
+++ b/lib/setUserInfo.js
@@ -1,17 +1,45 @@
+import Sequelize from 'sequelize'
 import getToken from './getToken'
 import models from '../models'
 
 export default async function setUserInfo(req) {
+	console.log('setUserInfo')
 	if (req.get('Authorization')) {
 		let userToken = getToken(req)
-		let userData = await models.User.findOne({
-			where: {
-				authToken: userToken
-			}
-		})
-		if (data.authToken && data.authToken == userToken && moment(data.tokenExpiration) > moment()) {
+		console.log('got the token in setuserinfo')
+
+		let userData
+		try {
+			userData = await models.User.findOne({
+				where: {
+					authToken: userToken
+				},
+				include: [
+					{
+						model: models.UserGroupMembership,
+						as: 'user',
+						// where: {
+							// userId: Sequelize.col('User.id')
+						// },
+						include: [
+							{
+								model: models.UserGroup,
+								as: 'userGroup',
+								// where: {
+									// id: Sequelize.col('UserGroupMembership.userGroupId')
+								// }
+							}
+						]
+					}
+				]
+			})
+		} catch (err) {
+			console.log('Error getting current user from database: ' + err)
+		}
+
+		if (userData.authToken && userData.authToken == userToken && moment(userData.tokenExpiration) > moment()) {
 			// this is a valid user with a non-expired token, so set some data on their request and return it
-			req.user = data
+			req.user = userData
 			return req
 		} else {
 			// for some reason this user is not valid, so just return the req object
@@ -21,4 +49,3 @@ export default async function setUserInfo(req) {
 		return req
 	}
 }
-

--- a/lib/setUserInfo.js
+++ b/lib/setUserInfo.js
@@ -31,6 +31,10 @@ export default async function setUserInfo(req) {
 			console.log('Error getting current user from database: ' + err)
 		}
 
+		if (!userData) {
+			return req
+		}
+
 		// simplify list of user's groups
 		userData.isAdmin = false
 		let userGroups = []

--- a/lib/setUserInfo.js
+++ b/lib/setUserInfo.js
@@ -17,17 +17,11 @@ export default async function setUserInfo(req) {
 				include: [
 					{
 						model: models.UserGroupMembership,
-						as: 'user',
-						// where: {
-							// userId: Sequelize.col('User.id')
-						// },
+						as: 'user'
 						include: [
 							{
 								model: models.UserGroup,
-								as: 'userGroup',
-								// where: {
-									// id: Sequelize.col('UserGroupMembership.userGroupId')
-								// }
+								as: 'userGroup'
 							}
 						]
 					}

--- a/lib/userIsAdmin.js
+++ b/lib/userIsAdmin.js
@@ -1,0 +1,14 @@
+export default function userIsAdmin(req) {
+	if (req.user) {
+		if (req.user.isAdmin) {
+			console.log('user is an admin')
+			return true
+		} else {
+			console.log('user is not an admin')
+			return false
+		}
+	} else {
+		console.log('user is not an admin')
+		return false
+	}
+}

--- a/lib/userIsAdmin.js
+++ b/lib/userIsAdmin.js
@@ -1,14 +1,11 @@
 export default function userIsAdmin(req) {
 	if (req.user) {
 		if (req.user.isAdmin) {
-			console.log('user is an admin')
 			return true
 		} else {
-			console.log('user is not an admin')
 			return false
 		}
 	} else {
-		console.log('user is not an admin')
 		return false
 	}
 }

--- a/models/index.js
+++ b/models/index.js
@@ -32,8 +32,6 @@ modelNames.forEach(modelName => {
 	}
 })
 
-sequelize.sync()
-
 db.sequelize = sequelize
 db.Sequelize = Sequelize
 

--- a/models/user.js
+++ b/models/user.js
@@ -13,6 +13,7 @@ module.exports = (sequelize, DataTypes) => {
 
 	User.associate = (models) => {
 		User.belongsTo(models.Election, { as: 'election' })
+		User.hasMany(models.UserGroupMembership, { as: 'user' })
 	}
 
   return User

--- a/models/userGroup.js
+++ b/models/userGroup.js
@@ -8,6 +8,7 @@ module.exports = (sequelize, DataTypes) => {
   })
 
 	UserGroup.associate = (models) => {
+		UserGroup.hasMany(models.UserGroupMembership, { as: 'userGroup' })
 	}
 
   return UserGroup

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -1,4 +1,5 @@
 import models from '../models'
+import userIsAdmin from '../lib/userIsAdmin'
 import express from 'express'
 
 const router = express.Router()

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -16,56 +16,68 @@ router.get('/:candidateId?', (req, res) => {
 })
 
 router.post('/', (req, res) => {
-	models.Candidate.create({
-		name: req.query.name,
-		description: req.query.description,
-		electionId: req.query.electionId,
-		positionId: req.query.positionId
-	})
-	.then(() => {
-		res.sendStatus(201) // Created
-	})
-	.error(() => {
-		res.sendStatus(500) // Internal server error
-	})
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Candidate.create({
+			name: req.query.name,
+			description: req.query.description,
+			electionId: req.query.electionId,
+			positionId: req.query.positionId
+		})
+		.then(() => {
+			res.sendStatus(201) // Created
+		})
+		.error(() => {
+			res.sendStatus(500) // Internal server error
+		})
+	}
 })
 
 router.patch('/:candidateId', (req, res) => {
-	models.Candidate.find({
-		where: {
-			id: req.params.candidateId
-		}
-	})
-	.then((candidate) => {
-		if (!candidate) {
-			res.sendStatus(404)
-			return
-		}
-		candidate.name = req.query.name || candidate.name
-		candidate.description = req.query.description || candidate.description
-		candidate.electionId = req.query.electionId || candidate.electionId
-		candidate.positionId = req.query.positionId || candidate.positionId
-		candidate.save().then(() => {
-			res.sendStatus(202)
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Candidate.find({
+			where: {
+				id: req.params.candidateId
+			}
 		})
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
+		.then((candidate) => {
+			if (!candidate) {
+				res.sendStatus(404)
+				return
+			}
+			candidate.name = req.query.name || candidate.name
+			candidate.description = req.query.description || candidate.description
+			candidate.electionId = req.query.electionId || candidate.electionId
+			candidate.positionId = req.query.positionId || candidate.positionId
+			candidate.save().then(() => {
+				res.sendStatus(202)
+			})
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 router.delete('/:candidateId', (req, res) => {
-	models.Candidate.destroy({
-		where: {
-			id: req.params.candidateId
-		}
-	})
-	.then(() => {
-		res.sendStatus(202)
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Candidate.destroy({
+			where: {
+				id: req.params.candidateId
+			}
+		})
+		.then(() => {
+			res.sendStatus(202)
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 module.exports = router

--- a/routes/candidates.js
+++ b/routes/candidates.js
@@ -5,15 +5,28 @@ import express from 'express'
 const router = express.Router()
 
 router.get('/:candidateId?', (req, res) => {
-	models.Candidate.findAll({
-		where: {
-			id: (req.params.candidateId == null) ? '*' : req.params.candidateId
-		}
-	})
-	.then((candidates) => {
-		console.log(candidates)
-		res.send(candidates)
-	})
+	if (req.params.candidateId) {
+		models.Candidate.findAll({
+			where: {
+				id: req.params.candidateId,
+				electionId: req.electionId
+			}
+		})
+		.then((candidates) => {
+			console.log(candidates)
+			res.send(candidates)
+		})
+	} else {
+		models.Candidate.findAll({
+			where: {
+				electionId: req.electionId
+			}
+		})
+		.then((candidates) => {
+			console.log(candidates)
+			res.send(candidates)
+		})
+	}
 })
 
 router.post('/', (req, res) => {

--- a/routes/elections.js
+++ b/routes/elections.js
@@ -6,16 +6,23 @@ const router = express.Router()
 
 // return election information for the given id
 router.get('/:electionId?', (req, res) => {
-	models.Election.findAll({
-		where: {
-			id: (req.params.electionId == null) ? '*' : req.params.electionId
-		}
-	})
-	.then((elections) => {
-		console.log(elections)
-		res.send(elections)
-	})
-
+	if (req.params.electionId) {
+		models.Election.findAll({
+			where: {
+				id: req.params.electionId
+			}
+		})
+		.then((elections) => {
+			console.log(elections)
+			res.send(elections)
+		})
+	} else {
+		models.Election.findAll()
+		.then((elections) => {
+			console.log(elections)
+			res.send(elections)
+		})
+	}
 })
 
 router.post('/', (req, res) => {

--- a/routes/elections.js
+++ b/routes/elections.js
@@ -1,5 +1,6 @@
 import models from '../models'
 import express from 'express'
+import userIsAdmin from '../lib/userIsAdmin'
 
 const router = express.Router()
 
@@ -18,53 +19,65 @@ router.get('/:electionId?', (req, res) => {
 })
 
 router.post('/', (req, res) => {
-	models.Election.create({
-		name: req.query.name,
-		description: req.query.description
-	})
-	.then(() => {
-		res.sendStatus(201) // Created
-	})
-	.error(() => {
-		res.sendStatus(500) // Internal server error
-	})
+	if (!userisadmin(req)) {
+		res.sendstatus(403)
+	} else {
+		models.Election.create({
+			name: req.query.name,
+			description: req.query.description
+		})
+		.then(() => {
+			res.sendStatus(201) // Created
+		})
+		.error(() => {
+			res.sendStatus(500) // Internal server error
+		})
+	}
 })
 
 router.patch('/:electionId', (req, res) => {
-	models.Election.find({
-		where: {
-			id: req.params.electionId
-		}
-	})
-	.then((election) => {
-		if (!election) {
-			res.sendStatus(404)
-			return
-		}
-		election.name = req.query.name || election.name
-		election.startDateTime = req.query.startDateTime || election.startDateTime
-		election.endDateTime = req.query.endDateTime || election.endDateTime
-		election.save().then(() => {
-			res.sendStatus(202)
+	if (!userisadmin(req)) {
+		res.sendstatus(403)
+	} else {
+		models.Election.find({
+			where: {
+				id: req.params.electionId
+			}
 		})
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
+		.then((election) => {
+			if (!election) {
+				res.sendStatus(404)
+				return
+			}
+			election.name = req.query.name || election.name
+			election.startDateTime = req.query.startDateTime || election.startDateTime
+			election.endDateTime = req.query.endDateTime || election.endDateTime
+			election.save().then(() => {
+				res.sendStatus(202)
+			})
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 router.delete('/:electionId', (req, res) => {
-	models.Election.destroy({
-		where: {
-			id: req.params.electionId
-		}
-	})
-	.then(() => {
-		res.sendStatus(202)
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
+	if (!userisadmin(req)) {
+		res.sendstatus(403)
+	} else {
+		models.Election.destroy({
+			where: {
+				id: req.params.electionId
+			}
+		})
+		.then(() => {
+			res.sendStatus(202)
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -3,7 +3,6 @@ import express from 'express'
 import moment from 'moment'
 import models from '../models'
 import qs from 'query-string'
-import userIsAuthenticated from '../lib/userIsAuthenticated'
 import getToken from '../lib/getToken'
 import fetch from 'node-fetch'
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -4,17 +4,13 @@ import moment from 'moment'
 import models from '../models'
 import qs from 'query-string'
 import userIsAuthenticated from '../lib/userIsAuthenticated'
+import getToken from '../lib/getToken'
 import fetch from 'node-fetch'
 
 const router = express.Router()
 
-const getToken = (tokString) => {
-	let tok = tokString.match('\"(.+)\"')[1]
-	return tok
-}
-
 router.post('/google', async (req, res) => {
-		let token = getToken(req.get('Authorization'))
+		let token = getToken(req)
 		let response = await fetch('https://www.googleapis.com/oauth2/v3/tokeninfo?' + qs.stringify({
 			id_token: token
 		}))

--- a/routes/positions.js
+++ b/routes/positions.js
@@ -5,15 +5,28 @@ import express from 'express'
 const router = express.Router()
 
 router.get('/:positionId?', (req, res) => {
-	models.Position.findAll({
-		where: {
-			id: (req.params.positionId == null) ? '*' : req.params.positionId
-		}
-	})
-	.then((position) => {
-		console.log(position)
-		res.send(position)
-	})
+	if (req.params.positionId) {
+		models.Position.findAll({
+			where: {
+				id: req.params.positionId,
+				electionId: req.electionId
+			}
+		})
+		.then((position) => {
+			console.log(position)
+			res.send(position)
+		})
+	} else {
+		models.Position.findAll({
+			where: {
+				electionId: req.electionId
+			}
+		})
+		.then((position) => {
+			console.log(position)
+			res.send(position)
+		})
+	}
 })
 
 router.post('/', (req, res) => {

--- a/routes/positions.js
+++ b/routes/positions.js
@@ -1,4 +1,5 @@
 import models from '../models'
+import userIsAdmin from '../lib/userIsAdmin'
 import express from 'express'
 
 const router = express.Router()

--- a/routes/positions.js
+++ b/routes/positions.js
@@ -16,54 +16,66 @@ router.get('/:positionId?', (req, res) => {
 })
 
 router.post('/', (req, res) => {
-	models.Position.create({
-		name: req.query.name,
-		description: req.query.description,
-		electionId: req.query.electionId
-	})
-	.then(() => {
-		res.sendStatus(201) // Created
-	})
-	.error(() => {
-		res.sendStatus(500) // Internal server error
-	})
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Position.create({
+			name: req.query.name,
+			description: req.query.description,
+			electionId: req.query.electionId
+		})
+		.then(() => {
+			res.sendStatus(201) // Created
+		})
+		.error(() => {
+			res.sendStatus(500) // Internal server error
+		})
+	}
 })
 
 router.patch('/:positionId', (req, res) => {
-	models.Position.find({
-		where: {
-			id: req.params.positionId
-		}
-	})
-	.then((pos) => {
-		if (!pos) {
-			res.sendStatus(404)
-			return
-		}
-		pos.name = req.query.name || pos.name
-		pos.description = req.query.description || pos.description
-		pos.electionId = req.query.electionId || pos.electionId
-		pos.save().then(() => {
-			res.sendStatus(202)
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Position.find({
+			where: {
+				id: req.params.positionId
+			}
 		})
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
+		.then((pos) => {
+			if (!pos) {
+				res.sendStatus(404)
+				return
+			}
+			pos.name = req.query.name || pos.name
+			pos.description = req.query.description || pos.description
+			pos.electionId = req.query.electionId || pos.electionId
+			pos.save().then(() => {
+				res.sendStatus(202)
+			})
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 router.delete('/:positionId', (req, res) => {
-	models.Position.destroy({
-		where: {
-			id: req.params.positionId
-		}
-	})
-	.then(() => {
-		res.sendStatus(202)
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Position.destroy({
+			where: {
+				id: req.params.positionId
+			}
+		})
+		.then(() => {
+			res.sendStatus(202)
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 module.exports = router

--- a/routes/userGroups.js
+++ b/routes/userGroups.js
@@ -14,15 +14,28 @@ router.use((req, res, next) => {
 })
 
 router.get('/:userGroupId', (req, res) => {
-	models.UserGroup.findAll({
-		where: {
-			id: (req.params.userGroupId == null) ? '*' : req.params.userGroupId
-		}
-	})
-	.then((vg) => {
-		console.log(vg)
-		res.send(vg)
-	})
+	if (req.params.userGroupId) {
+		models.UserGroup.findAll({
+			where: {
+				id: req.params.userGroupId,
+				electionId: req.electionId
+			}
+		})
+		.then((vg) => {
+			console.log(vg)
+			res.send(vg)
+		})
+	} else {
+		models.UserGroup.findAll({
+			where: {
+				electionId: req.electionId
+			}
+		})
+		.then((vg) => {
+			console.log(vg)
+			res.send(vg)
+		})
+	}
 })
 
 router.post('/', (req, res) => {

--- a/routes/userGroups.js
+++ b/routes/userGroups.js
@@ -3,6 +3,15 @@ import express from 'express'
 
 const router = express.Router()
 
+// all /userGroup routes should be admin restricted
+router.use((req, res, next) => {
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		next()
+	}
+})
+
 router.get('/:userGroupId', (req, res) => {
 	models.UserGroup.findAll({
 		where: {

--- a/routes/userGroups.js
+++ b/routes/userGroups.js
@@ -1,4 +1,5 @@
 import models from '../models'
+import userIsAdmin from '../lib/userIsAdmin'
 import express from 'express'
 
 const router = express.Router()

--- a/routes/users.js
+++ b/routes/users.js
@@ -8,12 +8,12 @@ const router = express.Router()
 router.use((req, res, next) => {
 	if (!userIsAdmin(req)) {
 		res.sendStatus(403)
+	} else {
+		next()
 	}
-	next()
 })
 
 router.get('/:userId?', (req, res) => {
-	console.log('resolving in route')
 	models.User.findAll({
 		where: {
 			id: (req.params.userId == null) ? '*' : req.params.userId

--- a/routes/users.js
+++ b/routes/users.js
@@ -14,22 +14,35 @@ router.use((req, res, next) => {
 })
 
 router.get('/:userId?', (req, res) => {
-	models.User.findAll({
-		where: {
-			id: (req.params.userId == null) ? '*' : req.params.userId
-		}
+	if (req.params.userId) {
+		models.User.findAll({
+			where: {
+				id: req.params.userId,
+				electionId: req.electionId
+			}
+		})
+		.then((user) => {
+			console.log(user)
+			res.send(user)
+		})
+	} else {
+		models.User.findAll({
+			where: {
+				electionId: req.electionId
+			}
+		})
+		.then((user) => {
+			console.log(user)
+			res.send(user)
+		})
+	}
 	})
-	.then((user) => {
-		console.log(user)
-		res.send(user)
-	})
-})
 
 router.post('/', (req, res) => {
 	if (Object.keys(req.query).length !== 0) {
 		models.User.create({
 			name: req.query.name,
-			electionId: req.query.electionId
+			electionId: req.electionId
 		})
 		.then(() => {
 			res.sendStatus(201) // Created

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,19 @@
 import models from '../models'
+import userIsAdmin from '../lib/userIsAdmin'
 import express from 'express'
 
 const router = express.Router()
 
+// all /user routes should be admin restricted
+router.use((req, res, next) => {
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	}
+	next()
+})
+
 router.get('/:userId?', (req, res) => {
+	console.log('resolving in route')
 	models.User.findAll({
 		where: {
 			id: (req.params.userId == null) ? '*' : req.params.userId

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -8,13 +8,23 @@ router.get('/:voteId?', (req, res) => {
 	if (!userIsAdmin(req)) {
 		res.sendStatus(403)
 	} else {
-		models.Vote.findall({
-			id: (req.params.voteId == null) ? '*' : req.params.voteId
-		})
-		.then((vote) => {
-			console.log(vote)
-			res.send(vote)
-		})
+		if (req.params.voteId == null) {
+			models.Vote.findAll()
+			.then((vote) => {
+				console.log(vote)
+				res.send(vote)
+			})
+		} else {
+			models.Vote.findAll({
+				where: {
+					id: req.params.voteId
+				}
+			})
+			.then((vote) => {
+				console.log(vote)
+				res.send(vote)
+			})
+		}
 	}
 })
 

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -4,13 +4,17 @@ import express from 'express'
 const router = express.Router()
 
 router.get('/:voteId?', (req, res) => {
-	models.Vote.findall({
-		id: (req.params.voteId == null) ? '*' : req.params.voteId
-	})
-	.then((vote) => {
-		console.log(vote)
-		res.send(vote)
-	})
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Vote.findall({
+			id: (req.params.voteId == null) ? '*' : req.params.voteId
+		})
+		.then((vote) => {
+			console.log(vote)
+			res.send(vote)
+		})
+	}
 })
 
 router.post('/', (req, res) => {
@@ -44,18 +48,21 @@ router.post('/', (req, res) => {
 // are not allowed to change their ballots after submission.
 
 router.delete('/:voteId', (req, res) => {
-	models.Vote.destroy({
-		where: {
-			id: req.params.voteId
-		}
-	})
-	.then(() => {
-		res.sendStatus(202)
-	})
-	.error(() => {
-		res.sendStatus(500)
-	})
-
+	if (!userIsAdmin(req)) {
+		res.sendStatus(403)
+	} else {
+		models.Vote.destroy({
+			where: {
+				id: req.params.voteId
+			}
+		})
+		.then(() => {
+			res.sendStatus(202)
+		})
+		.error(() => {
+			res.sendStatus(500)
+		})
+	}
 })
 
 module.exports = router

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -9,7 +9,11 @@ router.get('/:voteId?', (req, res) => {
 		res.sendStatus(403)
 	} else {
 		if (req.params.voteId == null) {
-			models.Vote.findAll()
+			models.Vote.findAll({
+				where: {
+					electionId: req.electionId
+				}
+			})
 			.then((vote) => {
 				console.log(vote)
 				res.send(vote)

--- a/routes/votes.js
+++ b/routes/votes.js
@@ -1,4 +1,5 @@
 import models from '../models'
+import userIsAdmin from '../lib/userIsAdmin'
 import express from 'express'
 
 const router = express.Router()

--- a/script/make_admin_usergroup.js
+++ b/script/make_admin_usergroup.js
@@ -1,0 +1,9 @@
+INSERT INTO `OlevilleVoting_development`.`UserGroup`
+(`name`,
+`createdAt`,
+`updatedAt`
+) VALUES (
+'ADMIN',
+now(),
+now());
+


### PR DESCRIPTION
This PR touches all the parts of the API flow.

Big changes include:
- Removed `sync()` from `models/index.js`, so that the database does not get updated every time the server starts. This allows us to properly associate all the models bidirectionally.
- Add script to create an `ADMIN` usergroup, which is used to determine if the user is able to access certain routes. The ID of this group can be changed in a config file.
- Mark specific routes as admin only.
- Add a bunch of try-catch blocks so that we're not ignoring promise rejection, which will kill the node process in the future.
- Stop using `*` in integer queries, as it only works with string queries in MySQL.

See comments in files for more details.