### PR TITLE
Use Docker.io for hosting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   db:
-    image: mysql:5.7.21
+    image: docker.io/mysql:5.7.21
     restart: unless-stopped
     networks:
       - voting
@@ -13,7 +13,7 @@ services:
       - './db:/var/lib/mysql'
 
   api:
-    image: oleville-voting:latest
+    image: docker.io/oleville/voting:latest
     depends_on: [ db ]
     restart: unless-stopped
     networks:


### PR DESCRIPTION
We prefix all Docker.io-hosted images with `docker.io/`, and now also
point the api service to the hosted image location.

Since we're not pushing secrets (or, at least, we'd better not be) we should be fine to go this route.