### PR TITLE
Rename candidateid → candidateId in the vote migration

### DIFF
--- a/migrations/20170903160056-create-vote.js
+++ b/migrations/20170903160056-create-vote.js
@@ -20,7 +20,7 @@ module.exports = {
 				allowNull: false,
 				type: Sequelize.DATE
 			},
-			candidateid: {
+			candidateId: {
 				allowNull: false,
 				type: Sequelize.INTEGER
 			},


### PR DESCRIPTION
This *may* require a complete drop/re-create, but it's what we
reference elsewhere, so it's probably a good idea to be consistent.

Closes #57.